### PR TITLE
unify the file path seprator

### DIFF
--- a/rice/embed.go
+++ b/rice/embed.go
@@ -52,6 +52,7 @@ func operationEmbed(pkg *build.Package) {
 				os.Exit(1)
 			}
 
+			path = strings.Replace(path, "\\", "/", -1)
 			if info.IsDir() {
 				dirData := &dirDataType{
 					Identifier: "dir_" + nextIdentifier(),


### PR DESCRIPTION
unify the file path seprator or `rice embed` won't work under `Windows`
