### PR TITLE
Fixes Readdir when reading appended boxes.

### DIFF
--- a/appended.go
+++ b/appended.go
@@ -75,8 +75,10 @@ func init() {
 		if dirName == "." {
 			dirName = ""
 		}
-		if dir := box.Files[dirName]; dir != nil {
-			dir.children = append(dir.children, af)
+		if fileName != "" { // don't make box root dir a child of itself
+			if dir := box.Files[dirName]; dir != nil {
+				dir.children = append(dir.children, af)
+			}
 		}
 	}
 }

--- a/file.go
+++ b/file.go
@@ -59,10 +59,10 @@ func (f *File) Stat() (os.FileInfo, error) {
 func (f *File) Readdir(count int) ([]os.FileInfo, error) {
 	if f.appendedF != nil {
 		if f.appendedF.dir {
-			fi := make([]os.FileInfo, len(f.appendedF.children))
+			fi := make([]os.FileInfo, 0, len(f.appendedF.children))
 			for _, childAppendedFile := range f.appendedF.children {
 				if childAppendedFile.dir {
-					fi = append(fi, f.appendedF.dirInfo)
+					fi = append(fi, childAppendedFile.dirInfo)
 				} else {
 					fi = append(fi, childAppendedFile.zipFile.FileInfo())
 				}


### PR DESCRIPTION
Thanks for developing this package!

I was having trouble using Readdir against appended / zipped boxes. The Fileinfos I was getting back were nil. Example:

``` go
    templateBox, err := rice.FindBox("tmpl")
    dir, err := templateBox.Open("/")
    finfos, err := dir.Readdir(0)

    // Load all files
    for _, f := range finfos {
        // f was returning nil...
    }
```

It also looks like there were problems with reading subdirectories. Please review my fix if you have a chance. Thanks!
