### PR TITLE
Adding a note about serving content at non-root locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ http.ListenAndServe(":8080", nil)
 
 **Service a static content folder over HTTP at a non-root location**
 ```go
-box := rice.MustFindBox("cssfiles").HTTPBox()
-server := http.StripPrefix("/css/", http.FileServer(box))
-http.Handle("/css/", server)
+box := rice.MustFindBox("cssfiles")
+cssFileServer := http.StripPrefix("/css/", http.FileServer(box.HTTPBox()))
+http.Handle("/css/", cssFileServer)
 http.ListenAndServe(":8080", nil)
 ```
 


### PR DESCRIPTION
This took me some time to track down, so I thought it would be useful to add to the README.  This is actually an issue with the Go APIs for `http` (_i.e.,_ it is not really a problem with `go.rice`).  But it could save people some time if they are trying to serve content from a non-root location so I think it is worth including.
