### PR TITLE
Make sure we close the open files each time.

### DIFF
--- a/appended.go
+++ b/appended.go
@@ -35,10 +35,11 @@ func init() {
 	if err != nil {
 		return // not apended or cant find self executable
 	}
-	rd, err := zipexe.Open(thisFile)
+	closer, rd, err := zipexe.Open(thisFile)
 	if err != nil {
 		return // not apended
 	}
+	defer closer.Close()
 
 	for _, f := range rd.File {
 		// get box and file name from f.Name

--- a/box.go
+++ b/box.go
@@ -267,11 +267,11 @@ func (b *Box) Bytes(name string) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
+		defer rc.Close()
 		cpy, err := ioutil.ReadAll(rc)
 		if err != nil {
 			return nil, err
 		}
-		rc.Close()
 		return cpy, nil
 	}
 

--- a/virtual.go
+++ b/virtual.go
@@ -131,9 +131,9 @@ func (vf *virtualFile) seek(offset int64, whence int) (int64, error) {
 	return vf.offset, nil
 }
 
-// vritualDir is a 'stateful' virtual directory.
-// vritualDir wraps an *EmbeddedDir for a call to Box.Open() and virtualizes 'closing'.
-// vritualDir is only internally visible and should be exposed through rice.File
+// virtualDir is a 'stateful' virtual directory.
+// virtualDir wraps an *EmbeddedDir for a call to Box.Open() and virtualizes 'closing'.
+// virtualDir is only internally visible and should be exposed through rice.File
 type virtualDir struct {
 	*embedded.EmbeddedDir
 	offset int // readdir positon on the directory

--- a/walk.go
+++ b/walk.go
@@ -15,6 +15,7 @@ func (b *Box) Walk(path string, walkFn filepath.WalkFunc) error {
 	if err != nil {
 		return err
 	}
+	defer pathFile.Close()
 
 	pathInfo, err := pathFile.Stat()
 	if err != nil {
@@ -64,6 +65,7 @@ func (b *Box) walk(path string, info os.FileInfo, walkFn filepath.WalkFunc) erro
 		if err != nil {
 			return err
 		}
+		defer fileObject.Close()
 
 		fileInfo, err := fileObject.Stat()
 		if err != nil {
@@ -92,6 +94,7 @@ func (b *Box) readDirNames(path string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer f.Close()
 
 	stat, err := f.Stat()
 	if err != nil {
@@ -103,7 +106,6 @@ func (b *Box) readDirNames(path string) ([]string, error) {
 	}
 
 	infos, err := f.Readdir(0)
-	f.Close()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
I'm trying to use https://github.com/inconshreveable/go-update and I ran into the issue where go.rice had open files.. so I couldn't rename the running executable under Windows.

This fixes it.