### PR TITLE
fix "assignment count mismatch: 3 = 2"

### DIFF
--- a/appended.go
+++ b/appended.go
@@ -33,13 +33,12 @@ func init() {
 	// find if exec is appended
 	thisFile, err := osext.Executable()
 	if err != nil {
-		return // not apended or cant find self executable
+		return // not appended or cant find self executable
 	}
-	closer, rd, err := zipexe.Open(thisFile)
+	rd, err := zipexe.Open(thisFile)
 	if err != nil {
-		return // not apended
+		return // not appended
 	}
-	defer closer.Close()
 
 	for _, f := range rd.File {
 		// get box and file name from f.Name


### PR DESCRIPTION
This fixes the "Assignment count mismatch: 3 = 2" compilation error introduced in 368fb46cb7fec929d69b5c865baa81b5598b3966

Now the situation is back to what it was before that pull-request: the zip file does not get closed, but at least it compiles.

Would you want me to create a wercker CI configuration so that the code is compiled and tested after each commit to master?
