### PR TITLE
wercker configuration

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -1,0 +1,31 @@
+box: wercker/golang
+
+build:
+  steps:
+    - setup-go-workspace
+    
+    - script:
+        name: get dependencies
+        code: |
+          go get -d -t ./...
+
+    - script:
+        name: build
+        code: |
+            go build -x ./...
+
+    - script:
+        name: test
+        code: |
+          go test -cover ./...
+
+    - script:
+        name: vet
+        code: |
+          go vet ./...
+        
+    - script:
+        name: lint
+        code: |
+          go get github.com/golang/lint/golint
+          golint .


### PR DESCRIPTION
Wercker is an online CI system, it is free for private/public repos while in beta. Once out of beta it will stay free for open-source projects  (see: https://twitter.com/Wercker/status/486148925376974848 )

Here is a wercker configuration that will build / test / vet / lint code whenever code is pushed to the repository (note that linting problems don't break the build).

Pull-Requests will be automatically built as well.

After merging the PR you should register on wercker.com and add the app for the CI to start.