### PR TITLE
Make sure we *still* close every open file

### DIFF
--- a/appended.go
+++ b/appended.go
@@ -8,8 +8,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/GeertJohan/go.rice/zipexe"
+
 	"bitbucket.org/kardianos/osext"
-	"github.com/daaku/go.zipexe"
 )
 
 // appendedBox defines an appended box
@@ -35,9 +36,15 @@ func init() {
 	if err != nil {
 		return // not appended or cant find self executable
 	}
-	rd, err := zipexe.Open(thisFile)
+	zipFile, zipSize, err := zipexe.Open(thisFile)
 	if err != nil {
 		return // not appended
+	}
+	defer zipFile.Close()
+
+	rd, err := zipexe.NewReader(zipFile, zipSize)
+	if err != nil {
+		return // not appended or not working
 	}
 
 	for _, f := range rd.File {

--- a/rice/append.go
+++ b/rice/append.go
@@ -11,6 +11,8 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/GeertJohan/go.rice/zipexe"
 )
 
 func operationAppend(pkg *build.Package) {
@@ -59,10 +61,12 @@ func operationAppend(pkg *build.Package) {
 	verbosef("Will append to file: %s\n", binfileName)
 
 	// check that command doesn't already have zip appended
-	if rd, _ := zipExeOpen(binfileName); rd != nil {
+	rd, _, err := zipexe.Open(binfileName)
+	if err != nil {
 		fmt.Printf("Cannot append to already appended executable. Please remove %s and build a fresh one.\n", binfileName)
 		os.Exit(1)
 	}
+	rd.Close()
 
 	// open binfile
 	binfile, err := os.OpenFile(binfileName, os.O_WRONLY, os.ModeAppend)

--- a/rice/append.go
+++ b/rice/append.go
@@ -11,8 +11,6 @@ import (
 	"runtime"
 	"strings"
 	"time"
-
-	"github.com/daaku/go.zipexe"
 )
 
 func operationAppend(pkg *build.Package) {
@@ -61,7 +59,7 @@ func operationAppend(pkg *build.Package) {
 	verbosef("Will append to file: %s\n", binfileName)
 
 	// check that command doesn't already have zip appended
-	if rd, _ := zipexe.Open(binfileName); rd != nil {
+	if rd, _ := ZipExeOpen(binfileName); rd != nil {
 		fmt.Printf("Cannot append to already appended executable. Please remove %s and build a fresh one.\n", binfileName)
 		os.Exit(1)
 	}

--- a/rice/append.go
+++ b/rice/append.go
@@ -59,7 +59,7 @@ func operationAppend(pkg *build.Package) {
 	verbosef("Will append to file: %s\n", binfileName)
 
 	// check that command doesn't already have zip appended
-	if rd, _ := ZipExeOpen(binfileName); rd != nil {
+	if rd, _ := zipExeOpen(binfileName); rd != nil {
 		fmt.Printf("Cannot append to already appended executable. Please remove %s and build a fresh one.\n", binfileName)
 		os.Exit(1)
 	}

--- a/rice/zipexe.go
+++ b/rice/zipexe.go
@@ -13,7 +13,7 @@ import (
 // Ripped from daaku/go.zipexe to fix Open() signatures
 
 // Opens a zip file by path.
-func ZipExeOpen(path string) (io.Closer, *zip.Reader, error) {
+func zipExeOpen(path string) (io.Closer, *zip.Reader, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return nil, nil, err
@@ -22,7 +22,7 @@ func ZipExeOpen(path string) (io.Closer, *zip.Reader, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	zr, err := NewZipExeReader(file, finfo.Size())
+	zr, err := newZipExeReader(file, finfo.Size())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -31,7 +31,7 @@ func ZipExeOpen(path string) (io.Closer, *zip.Reader, error) {
 
 // Open a zip file, specially handling various binaries that may have been
 // augmented with zip data.
-func NewZipExeReader(rda io.ReaderAt, size int64) (*zip.Reader, error) {
+func newZipExeReader(rda io.ReaderAt, size int64) (*zip.Reader, error) {
 	handlers := []func(io.ReaderAt, int64) (*zip.Reader, error){
 		zip.NewReader,
 		zipExeReaderMacho,

--- a/rice/zipexe.go
+++ b/rice/zipexe.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"archive/zip"
+	"debug/elf"
+	"debug/macho"
+	"debug/pe"
+	"errors"
+	"io"
+	"os"
+)
+
+// Ripped from daaku/go.zipexe to fix Open() signatures
+
+// Opens a zip file by path.
+func ZipExeOpen(path string) (io.Closer, *zip.Reader, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	finfo, err := file.Stat()
+	if err != nil {
+		return nil, nil, err
+	}
+	zr, err := NewZipExeReader(file, finfo.Size())
+	if err != nil {
+		return nil, nil, err
+	}
+	return file, zr, nil
+}
+
+// Open a zip file, specially handling various binaries that may have been
+// augmented with zip data.
+func NewZipExeReader(rda io.ReaderAt, size int64) (*zip.Reader, error) {
+	handlers := []func(io.ReaderAt, int64) (*zip.Reader, error){
+		zip.NewReader,
+		zipExeReaderMacho,
+		zipExeReaderElf,
+		zipExeReaderPe,
+	}
+
+	for _, handler := range handlers {
+		zfile, err := handler(rda, size)
+		if err == nil {
+			return zfile, nil
+		}
+	}
+	return nil, errors.New("Couldn't Open As Executable")
+}
+
+// zipExeReaderMacho treats the file as a Mach-O binary
+// (Mac OS X / Darwin executable) and attempts to find a zip archive.
+func zipExeReaderMacho(rda io.ReaderAt, size int64) (*zip.Reader, error) {
+	file, err := macho.NewFile(rda)
+	if err != nil {
+		return nil, err
+	}
+
+	var max int64
+	for _, load := range file.Loads {
+		seg, ok := load.(*macho.Segment)
+		if ok {
+			// Check if the segment contains a zip file
+			if zfile, err := zip.NewReader(seg, int64(seg.Filesz)); err == nil {
+				return zfile, nil
+			}
+
+			// Otherwise move end of file pointer
+			end := int64(seg.Offset + seg.Filesz)
+			if end > max {
+				max = end
+			}
+		}
+	}
+
+	// No zip file within binary, try appended to end
+	section := io.NewSectionReader(rda, max, size-max)
+	return zip.NewReader(section, section.Size())
+}
+
+// zipExeReaderPe treats the file as a Portable Exectuable binary
+// (Windows executable) and attempts to find a zip archive.
+func zipExeReaderPe(rda io.ReaderAt, size int64) (*zip.Reader, error) {
+	file, err := pe.NewFile(rda)
+	if err != nil {
+		return nil, err
+	}
+
+	var max int64
+	for _, sec := range file.Sections {
+		// Check if this section has a zip file
+		if zfile, err := zip.NewReader(sec, int64(sec.Size)); err == nil {
+			return zfile, nil
+		}
+
+		// Otherwise move end of file pointer
+		end := int64(sec.Offset + sec.Size)
+		if end > max {
+			max = end
+		}
+	}
+
+	// No zip file within binary, try appended to end
+	section := io.NewSectionReader(rda, max, size-max)
+	return zip.NewReader(section, section.Size())
+}
+
+// zipExeReaderElf treats the file as a ELF binary
+// (linux/BSD/etc... executable) and attempts to find a zip archive.
+func zipExeReaderElf(rda io.ReaderAt, size int64) (*zip.Reader, error) {
+	file, err := elf.NewFile(rda)
+	if err != nil {
+		return nil, err
+	}
+
+	var max int64
+	for _, sect := range file.Sections {
+		if sect.Type == elf.SHT_NOBITS {
+			continue
+		}
+
+		// Check if this section has a zip file
+		if zfile, err := zip.NewReader(sect, int64(sect.Size)); err == nil {
+			return zfile, nil
+		}
+
+		// Otherwise move end of file pointer
+		end := int64(sect.Offset + sect.Size)
+		if end > max {
+			max = end
+		}
+	}
+
+	// No zip file within binary, try appended to end
+	section := io.NewSectionReader(rda, max, size-max)
+	return zip.NewReader(section, section.Size())
+}

--- a/zipexe/zipexe.go
+++ b/zipexe/zipexe.go
@@ -1,4 +1,4 @@
-package main
+package zipexe
 
 import (
 	"archive/zip"
@@ -12,26 +12,27 @@ import (
 
 // Ripped from daaku/go.zipexe to fix Open() signatures
 
+type ReaderAtCloser interface{
+	io.ReaderAt
+	io.Closer
+}
+
 // Opens a zip file by path.
-func zipExeOpen(path string) (io.Closer, *zip.Reader, error) {
+func Open(path string) (ReaderAtCloser, int64, error) {
 	file, err := os.Open(path)
 	if err != nil {
-		return nil, nil, err
+		return nil, 0, err
 	}
 	finfo, err := file.Stat()
 	if err != nil {
-		return nil, nil, err
+		return nil, 0, err
 	}
-	zr, err := newZipExeReader(file, finfo.Size())
-	if err != nil {
-		return nil, nil, err
-	}
-	return file, zr, nil
+	return file, finfo.Size(),  nil
 }
 
 // Open a zip file, specially handling various binaries that may have been
 // augmented with zip data.
-func newZipExeReader(rda io.ReaderAt, size int64) (*zip.Reader, error) {
+func NewReader(rda io.ReaderAt, size int64) (*zip.Reader, error) {
 	handlers := []func(io.ReaderAt, int64) (*zip.Reader, error){
 		zip.NewReader,
 		zipExeReaderMacho,


### PR DESCRIPTION
The `Open()` signature from daaku/go.zipexe is pretty non-standard, as it returns a Reader instead of a closeable file, preventing anyone from closing the file, breaking the `Open()` semantics.  Since that project hasn't moved in 2 years, and is a simple 135 lines file, I added it here, and tweaked Open to return something we can close, as well as anything we need to read the zip content.

This fixes the issue I introduced (mismatched 2 == 3 thing) as well as file closing.

/cc @nwolff 