### PR TITLE
fix import of kardianos/osext

### DIFF
--- a/appended.go
+++ b/appended.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"bitbucket.org/kardianos/osext"
+	"github.com/kardianos/osext"
 	"github.com/daaku/go.zipexe"
 )
 


### PR DESCRIPTION
kardianos/osext has moved to github and the build breaks with go 1.4 canonical imports