### PR TITLE
add rice.LocateWorkingDirectory support

### DIFF
--- a/box.go
+++ b/box.go
@@ -67,6 +67,23 @@ func findBox(name string, order []LocateMethod) (*Box, error) {
 				continue
 			}
 			return b, nil
+		case LocateWorkingDirectory:
+			// resolve absolute directory path
+			err := b.resolveAbsolutePathFromWorkingDirectory()
+			if err != nil {
+				continue
+			}
+			// check if absolutePath exists on filesystem
+			info, err := os.Stat(b.absolutePath)
+			if err != nil {
+				continue
+			}
+			// check if absolutePath is actually a directory
+			if !info.IsDir() {
+				err = errors.New("given name/path is not a directory")
+				continue
+			}
+			return b, nil
 		}
 	}
 
@@ -124,6 +141,15 @@ func (b *Box) resolveAbsolutePathFromCaller() error {
 	b.absolutePath = path
 	return nil
 
+}
+
+func (b *Box) resolveAbsolutePathFromWorkingDirectory() error {
+	path, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	b.absolutePath = filepath.Join(path, b.name)
+	return nil
 }
 
 // IsEmbedded indicates wether this box was embedded into the application

--- a/config.go
+++ b/config.go
@@ -4,9 +4,10 @@ package rice
 type LocateMethod int
 
 const (
-	LocateFS       = LocateMethod(iota) // Locate on the filesystem.
-	LocateAppended                      // Locate boxes appended to the executable.
-	LocateEmbedded                      // Locate embedded boxes.
+	LocateFS               = LocateMethod(iota) // Locate on the filesystem according to package path.
+	LocateAppended                              // Locate boxes appended to the executable.
+	LocateEmbedded                              // Locate embedded boxes.
+	LocateWorkingDirectory                      // Locate on the binary working directory
 )
 
 // Config allows customizing the box lookup behavior.


### PR DESCRIPTION
Whit `rice.LocateFS`, `rice.FindBox` would lookup box directory from the package path where `FindBox` is called, this is fine when your main program use `github.com/GeertJohan/go.rice` directly. 

But it has trouble when you use `github.com/GeertJohan/go.rice` in your own packages, and then import your own package from the main program.

`rice.LocateWorkingDirectory` support is a minor change to support looking up box directory from the binary working directory :smile: 
