### PR TITLE
Change embed-go to generate a single source file per package

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The `rice` tool lets you add the resources to a binary executable so the files a
 #### embed-go
 **Embed resources by generating Go source code**
 
-This method must be executed before building. It generates Go source files that are compiled by the go compiler into the binary.
+This method must be executed before building. It generates a single Go source file called *rice-box.go* for each package, that is compiled by the go compiler into the binary.
 
 The downside with this option is that the generated go source files can become very large, which will slow down compilation and require lots of memory to compile.
 
@@ -149,4 +149,3 @@ You will find package documentation at [godoc.org/github.com/GeertJohan/go.rice]
 
  [license]: https://github.com/GeertJohan/go.rice/blob/master/LICENSE
  [godoc]: http://godoc.org/github.com/GeertJohan/go.rice
- 

--- a/rice/templates.go
+++ b/rice/templates.go
@@ -19,6 +19,7 @@ import (
 	"time"
 )
 
+{{range .Boxes}}
 func init() {
 
 	// define files
@@ -60,15 +61,20 @@ func init() {
 			{{end}}
 		},
 	})
-}`)
+}
+{{end}}`)
 	if err != nil {
 		fmt.Printf("error parsing embedded box template: %s\n", err)
 		os.Exit(-1)
 	}
 }
 
-type boxDataType struct {
+type embedFileDataType struct {
 	Package string
+	Boxes   []*boxDataType
+}
+
+type boxDataType struct {
 	BoxName string
 	UnixNow int64
 	Files   []*fileDataType


### PR DESCRIPTION
The current file name generation is brittle, and breaks in a number of
corner-cases - see issue #67.

This patch refactors the way embedded files are generated. Instead of
generating one file per box, we generate a single file per package, with a
fixed name (rice-box.go), which includes one init() method per box. This
eliminates pretty much all the ambiguity and complexity around file name
generation.

Fixes #67