### PR TITLE
Real modification time of embedded boxes

### DIFF
--- a/rice/embed-go.go
+++ b/rice/embed-go.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 )
 
 const boxFilename = "rice-box.go"
@@ -45,19 +44,21 @@ func operationEmbedGo(pkg *build.Package) {
 		// verbose info
 		verbosef("embedding box '%s' to '%s'\n", boxname, boxFilename)
 
-		// create box datastructure (used by template)
-		box := &boxDataType{
-			BoxName: boxname,
-			UnixNow: time.Now().Unix(),
-			Files:   make([]*fileDataType, 0),
-			Dirs:    make(map[string]*dirDataType),
-		}
-
+		// read box metadata
 		boxInfo, ierr := os.Stat(boxPath)
 		if ierr != nil {
 			fmt.Printf("Error: unable to access box at %s\n", boxPath)
 			os.Exit(1)
 		}
+
+		// create box datastructure (used by template)
+		box := &boxDataType{
+			BoxName: boxname,
+			UnixNow: boxInfo.ModTime().Unix(),
+			Files:   make([]*fileDataType, 0),
+			Dirs:    make(map[string]*dirDataType),
+		}
+
 		if !boxInfo.IsDir() {
 			fmt.Printf("Error: Box %s must point to a directory but points to %s instead\n",
 				boxname, boxPath)

--- a/rice/embed-syso.go
+++ b/rice/embed-syso.go
@@ -12,7 +12,6 @@ import (
 	"regexp"
 	"strings"
 	"text/template"
-	"time"
 
 	"github.com/GeertJohan/go.rice/embedded"
 	"github.com/akavel/rsrc/coff"
@@ -94,10 +93,17 @@ func operationEmbedSyso(pkg *build.Package) {
 		verbosef("embedding box '%s'\n", boxname)
 		verbosef("\tto file %s\n", boxFilename)
 
+		// read box metadata
+		boxInfo, ierr := os.Stat(boxPath)
+		if ierr != nil {
+			fmt.Printf("Error: unable to access box at %s\n", boxPath)
+			os.Exit(1)
+		}
+
 		// create box datastructure (used by template)
 		box := &embedded.EmbeddedBox{
 			Name:      boxname,
-			Time:      time.Now(),
+			Time:      boxInfo.ModTime(),
 			EmbedType: embedded.EmbedTypeSyso,
 			Files:     make(map[string]*embedded.EmbeddedFile),
 			Dirs:      make(map[string]*embedded.EmbeddedDir),


### PR DESCRIPTION
Hi,

I discovered a problem related to rebuilding embedded resources. When your re-embed the same files, the generated rice-box.go file changes - the box's Time attribute is being set to time.Now() value, which in fact is wrong, because it is not touched. 
I decided to change its value to modification time and open a pull request with those changes.

Happy New Year,
Marcin