### PR TITLE
Fix huge memory usage during compilation of embed-go files, fix referencing via variable using non standard config

### DIFF
--- a/rice/find_test.go
+++ b/rice/find_test.go
@@ -76,6 +76,39 @@ func main() {
 	}
 }
 
+func TestFindOneBoxViaVariable(t *testing.T) {
+
+	pkg, cleanup, err := setUpTestPkg("foobar", []sourceFile{
+		{
+			"boxes.go",
+			[]byte(`package main
+
+import (
+	"github.com/GeertJohan/go.rice"
+)
+
+func main() {
+	conf := rice.Config{
+		LocateOrder: []rice.LocateMethod{rice.LocateEmbedded, rice.LocateAppended, rice.LocateFS},
+	}
+	conf.MustFindBox("foo")
+}
+`),
+		},
+	})
+	defer cleanup()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	expectedBoxes := []string{"foo"}
+	boxMap := findBoxes(pkg)
+	if err := expectBoxes(expectedBoxes, boxMap); err != nil {
+		t.Error(err)
+	}
+}
+
 func TestFindMultipleBoxes(t *testing.T) {
 	pkg, cleanup, err := setUpTestPkg("foobar", []sourceFile{
 		{

--- a/rice/templates.go
+++ b/rice/templates.go
@@ -26,7 +26,7 @@ func init() {
 	{{range .Files}}{{.Identifier}} := &embedded.EmbeddedFile{
 		Filename:    ` + "`" + `{{.FileName}}` + "`" + `,
 		FileModTime: time.Unix({{.ModTime}}, 0),
-		Content:     string({{.Content | printf "%#v"}}), //++ TODO: optimize? (double allocation) or does compiler already optimize this?
+		Content:     string({{.Content | printf "%q"}}), //++ TODO: optimize? (double allocation) or does compiler already optimize this?
 	}
 	{{end}}
 

--- a/rice/templates.go
+++ b/rice/templates.go
@@ -26,7 +26,7 @@ func init() {
 	{{range .Files}}{{.Identifier}} := &embedded.EmbeddedFile{
 		Filename:    ` + "`" + `{{.FileName}}` + "`" + `,
 		FileModTime: time.Unix({{.ModTime}}, 0),
-		Content:     string({{.Content | printf "%q"}}), //++ TODO: optimize? (double allocation) or does compiler already optimize this?
+		Content:     string({{.Content | printf "%q"}}), 
 	}
 	{{end}}
 


### PR DESCRIPTION
This very small change fixes memory usage during compilation. When compiling the swagger ui 1.2 dist folder it required up to 4GB of RAM during compilation. Now it's negligble. The underlying issue in the compiler is here: https://github.com/golang/go/issues/14082

This also has the side effect of creating smaller generated files.