### PR TITLE
Fix leaking zip file when appending boxes to an executable

### DIFF
--- a/rice/append.go
+++ b/rice/append.go
@@ -40,6 +40,10 @@ func operationAppend(pkgs []*build.Package) {
 		fmt.Printf("Error creating tmp zipfile: %s\n", err)
 		os.Exit(1)
 	}
+	defer func() {
+		tmpZipfile.Close()
+		os.Remove(tmpZipfileName)
+	}()
 
 	// find abs path for binary file
 	binfileName, err := filepath.Abs(flags.Append.Executable)


### PR DESCRIPTION
Make sure to close the zip file and remove it from the filesystem after
usage.