### PR TITLE
--exclude-path flag

### DIFF
--- a/rice/find_test.go
+++ b/rice/find_test.go
@@ -190,7 +190,7 @@ func FindBox(s string) {
 func LoadBoxes() {
 	rice := fakerice{}
 	rice.FindBox("foo")
-	
+
 	FindBox("bar")
 }
 `),
@@ -232,7 +232,7 @@ func FindBox(s string) {
 func LoadBoxes1() {
 	rice := fakerice{}
 	rice.FindBox("foo")
-	
+
 	FindBox("bar")
 }
 `),

--- a/rice/flags.go
+++ b/rice/flags.go
@@ -11,7 +11,8 @@ import (
 // flags
 var flags struct {
 	Verbose     bool     `long:"verbose" short:"v" description:"Show verbose debug information"`
-	ImportPaths []string `long:"import-path" short:"i" description:"Import path(s) to use. Using PWD when left empty. Specify multiple times for more import paths to append"`
+	ImportPaths []string `long:"import-path" short:"i" description:"Import path(s) to use. Using PWD when left empty. Specify multiple times for more import paths to append."`
+	ExcludePaths []string `long:"exclude-path" short:"e" description:"Exclude path(s).  Specify multiple times to exclude paths to append."`
 
 	Append struct {
 		Executable string `long:"exec" description:"Executable to append" required:"true"`

--- a/rice/main.go
+++ b/rice/main.go
@@ -22,7 +22,7 @@ func main() {
 	switch flagsParser.Active.Name {
 	case "embed", "embed-go":
 		for _, pkg := range pkgs {
-			operationEmbedGo(pkg)
+			operationEmbedGo(pkg, flags.ExcludePaths)
 		}
 	case "embed-syso":
 		log.Println("WARNING: embedding .syso is experimental..")

--- a/rice/templates.go
+++ b/rice/templates.go
@@ -26,7 +26,7 @@ func init() {
 	{{range .Files}}{{.Identifier}} := &embedded.EmbeddedFile{
 		Filename:    ` + "`" + `{{.FileName}}` + "`" + `,
 		FileModTime: time.Unix({{.ModTime}}, 0),
-		Content:     string({{.Content | printf "%q"}}), 
+		Content:     string({{.Content | printf "%q"}}),
 	}
 	{{end}}
 


### PR DESCRIPTION
Adds an `--exclude-path` / `-e` flag for exclude files or directories, such as `-e gulpfile.js -e package.json -e node_modules/`.  Only works with `embed-go` action.