### PR TITLE
Add travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: go
+
+go:
+    - master
+    - 1.x.x
+    - 1.8.x
+    - 1.7.x
+    - 1.6.x
+    - 1.5.x
+
+install:
+    - go get -t ./...
+    - env
+    - if [ "${TRAVIS_GO_VERSION%.*}" != "1.5" ]; then go get github.com/golang/lint/golint; fi
+script:
+    - go build -x ./...
+    - go test -cover ./...
+    - go vet ./...
+    - if [ "${TRAVIS_GO_VERSION%.*}" != "1.5" ]; then golint .; fi


### PR DESCRIPTION
Wercker doesn't work for some reason (plus they've just been bough by Oracle, ugh), so I added a .travis.yml file. You'll have to log in to travis and activate it for your repository.

You can see the build in my repo here: https://travis-ci.org/nkovacs/go.rice/builds/223069637

The golint step is the same as in wercker.yml, but it should be `golint ./...` to check the subpackages too. Plus it doesn't seem to return a nonzero exit code, even though it prints some errors. But that's probably not a bad thing, since you don't have to fix all of golint's errors.
