### PR TITLE
Do not create empty box file if no calls to rice.FindBox() are found

### DIFF
--- a/rice/embed-go.go
+++ b/rice/embed-go.go
@@ -15,15 +15,7 @@ import (
 
 const boxFilename = "rice-box.go"
 
-func writeBoxesGo(pkg *build.Package, out io.Writer) error {
-	boxMap := findBoxes(pkg)
-
-	// notify user when no calls to rice.FindBox are made (is this an error and therefore os.Exit(1) ?
-	if len(boxMap) == 0 {
-		fmt.Println("no calls to rice.FindBox() found")
-		return nil
-	}
-
+func writeBoxesGo(pkg *build.Package, boxMap map[string]bool, out io.Writer) error {
 	verbosef("\n")
 
 	var boxes []*boxDataType
@@ -145,6 +137,14 @@ func writeBoxesGo(pkg *build.Package, out io.Writer) error {
 }
 
 func operationEmbedGo(pkg *build.Package) {
+	boxMap := findBoxes(pkg)
+
+	// notify user when no calls to rice.FindBox are made (is this an error and therefore os.Exit(1) ?
+	if len(boxMap) == 0 {
+		fmt.Println("no calls to rice.FindBox() found")
+		os.Exit(0) // to keep compatibility with previous versions
+	}
+
 	// create go file for box
 	boxFile, err := os.Create(filepath.Join(pkg.Dir, boxFilename))
 	if err != nil {
@@ -153,7 +153,7 @@ func operationEmbedGo(pkg *build.Package) {
 	}
 	defer boxFile.Close()
 
-	err = writeBoxesGo(pkg, boxFile)
+	err = writeBoxesGo(pkg, boxMap, boxFile)
 	if err != nil {
 		log.Printf("error creating embedded box file: %s\n", err)
 		os.Exit(1)

--- a/rice/embed-go_test.go
+++ b/rice/embed-go_test.go
@@ -530,7 +530,7 @@ func main() {
 
 	var buffer bytes.Buffer
 
-	err = writeBoxesGo(pkg, &buffer)
+	err = writeBoxesGo(pkg, findBoxes(pkg), &buffer)
 	if err != nil {
 		t.Error(err)
 		return


### PR DESCRIPTION
After PR #93 was merged, calling `rice embed-go` for a package where go.rice is not actually used would create an empty **rice-box.go** file. Having empty **rice-box.go** file (without package declaration) makes package not build-able until this file is removed.

We stumbled on this issue because we call `rice embed-go` as a build step when building binaries without checking if go.rice is actually used.

This PR moves rice box usage detection before rice box file is created to restore old command line tool behavior.