### PR TITLE
goimport-friendly template.

### DIFF
--- a/rice/templates.go
+++ b/rice/templates.go
@@ -15,8 +15,9 @@ func init() {
 	tmplEmbeddedBox, err = template.New("embeddedBox").Parse(`package {{.Package}}
 
 import (
-	"github.com/GeertJohan/go.rice/embedded"
 	"time"
+
+	"github.com/GeertJohan/go.rice/embedded"
 )
 
 {{range .Boxes}}


### PR DESCRIPTION
This stops goimport from persistently trying to reformat `rice-box.go` files by grouping imports the way it expects. We use a combination of `goimport` and `rice embed-go` to embed data in binaries, and our CI "check that rice-box.go files are up to date" script causes goimport errors; running `goimport`, in turn, causes the files to be modified back the next time we run `rice`.