### PR TITLE
add mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,13 @@
+module github.com/GeertJohan/go.rice
+
+go 1.12
+
+require (
+	github.com/GeertJohan/go.incremental v0.0.0-20161212213043-1172aab96510
+	github.com/akavel/rsrc v0.8.0
+	github.com/daaku/go.zipexe v1.0.0
+	github.com/davecgh/go-spew v1.1.1
+	github.com/jessevdk/go-flags v1.4.0
+	github.com/nkovacs/streamquote v0.0.0-20170412213628-49af9bddb229
+	github.com/valyala/fasttemplate v1.0.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,16 @@
+github.com/GeertJohan/go.incremental v0.0.0-20161212213043-1172aab96510 h1:XKmpFaGpsBo5B7NC6RxawBYk6BFi0a6fw03J5PYW/9g=
+github.com/GeertJohan/go.incremental v0.0.0-20161212213043-1172aab96510/go.mod h1:0K8QLSiwClOppBKLLSRX1sFvYdX5/fWqAZkjboOEzak=
+github.com/akavel/rsrc v0.8.0 h1:zjWn7ukO9Kc5Q62DOJCcxGpXC18RawVtYAGdz2aLlfw=
+github.com/akavel/rsrc v0.8.0/go.mod h1:uLoCtb9J+EyAqh+26kdrTgmzRBFPGOolLWKpdxkKq+c=
+github.com/daaku/go.zipexe v1.0.0 h1:VSOgZtH418pH9L16hC/JrgSNJbbAL26pj7lmD1+CGdY=
+github.com/daaku/go.zipexe v1.0.0/go.mod h1:z8IiR6TsVLEYKwXAoE/I+8ys/sDkgTzSL0CLnGVd57E=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGARJA=
+github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/nkovacs/streamquote v0.0.0-20170412213628-49af9bddb229 h1:E2B8qYyeSgv5MXpmzZXRNp8IAQ4vjxIjhpAf5hv/tAg=
+github.com/nkovacs/streamquote v0.0.0-20170412213628-49af9bddb229/go.mod h1:0aYXnNPJ8l7uZxf45rWW1a/uME32OF0rhiYGNQ2oF2E=
+github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
+github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
+github.com/valyala/fasttemplate v1.0.0 h1:MCROMI9ZxNYyLvdmeQErZcgsUjsxARzi1SnHWYo3TnM=
+github.com/valyala/fasttemplate v1.0.0/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=


### PR DESCRIPTION
- [go modules](https://github.com/golang/go/wiki/Modules) will be enabled in 1.13
- `go mod tidy` was also run to include required dependencies
  - if you would like to only consume valid releases, this can block on:
    - [ ] GeertJohan/go.incremental#3
    - [x] valyala/fasttemplate#14
    - [ ] nkovacs/streamquote#1
    - [x] daaku/go.zipexe#3
    - [x] akavel/rsrc#24
  - this will remove all `// indirect` dependencies
  - this could also be done later
- after merge it would be nice if you would tag this repo: e.g. `v1.0.0`
  - this will allow consumers something more consistent and readable than `v0.0.0-20181229203832-0af3f3b09a0a`