### PR TITLE
prevent recursive structure in embedded.EmbeddedBox.Link

### DIFF
--- a/embedded/embedded.go
+++ b/embedded/embedded.go
@@ -30,6 +30,10 @@ func (e *EmbeddedBox) Link() {
 		ed.ChildFiles = make([]*EmbeddedFile, 0)
 	}
 	for path, ed := range e.Dirs {
+		// skip for root, it'll create a recursion
+		if path == "" {
+			continue
+		}
 		parentDirpath, _ := filepath.Split(path)
 		if strings.HasSuffix(parentDirpath, "/") {
 			parentDirpath = parentDirpath[:len(parentDirpath)-1]


### PR DESCRIPTION
## description
I came across a recursive link to the root directory of `embedded.EmbedTypeSyso` `embedded.EmbeddedBox`s. More specifically, for `embedded.EmbeddedBox.Filename == ""` `embedded.EmbeddedBox.Dirs` contains a reference to itself. 

This causes `Box.Walk` to terminate early.

## root cause
The flaw appears to be a missing check in `embedded.EmbeddedBox.Link` where, unlike [`rice.writeBoxesGo`](https://github.com/GeertJohan/go.rice/blob/0af3f3b09a0a8b391f63ab52ba5ab50f84fabd30/rice/embed-go.go#L89) and [`rice.operationEmbedSyso`](https://github.com/GeertJohan/go.rice/blob/0af3f3b09a0a8b391f63ab52ba5ab50f84fabd30/rice/embed-syso.go#L130), root detection [`path == 0`] does not occur.