### PR TITLE
remove print from embedded.EmbeddedBox.Link

### DIFF
--- a/embedded/embedded.go
+++ b/embedded/embedded.go
@@ -24,8 +24,7 @@ type EmbeddedBox struct {
 
 // Link creates the ChildDirs and ChildFiles links in all EmbeddedDir's
 func (e *EmbeddedBox) Link() {
-	for path, ed := range e.Dirs {
-		fmt.Println(path)
+	for _, ed := range e.Dirs {
 		ed.ChildDirs = make([]*EmbeddedDir, 0)
 		ed.ChildFiles = make([]*EmbeddedFile, 0)
 	}


### PR DESCRIPTION
## description
When consuming this library in a command line binary, I had trouble using `os.Stdout` programmatically, due to the extra output from `go.rice` generated by during the `init` phase.

## root cause
`embedded.EmbeddedBox.Link` prints using [`fmt.Println`](https://github.com/GeertJohan/go.rice/blob/0af3f3b09a0a8b391f63ab52ba5ab50f84fabd30/embedded/embedded.go#L28)

## alternatives
I prefer libraries to not interact with `os.Stdout` as it is a side effect that is not usable by consumers. Furthermore, while this pattern is fine for things like webservers that have logs for `os.Stdout`, it is incompatible with command line utilities that use `os.Stdout` for message passing.

If you do like this functionality, it could be hidden behind a [`rice.verbosef`](https://github.com/GeertJohan/go.rice/blob/master/rice/main.go#L83)-like function, configurable via api, or sent to `os.Stderr`, but either option makes this output nigh unusable programmatically.