### PR TITLE
add --tags for build.AllTags

### DIFF
--- a/rice/flags.go
+++ b/rice/flags.go
@@ -22,6 +22,8 @@ var flags struct {
 	EmbedGo   struct{} `command:"embed-go" alias:"embed"`
 	EmbedSyso struct{} `command:"embed-syso"`
 	Clean     struct{} `command:"clean"`
+
+	Tags []string `long:"tags" description:"Tags to use"`
 }
 
 // flags parser

--- a/rice/flags.go
+++ b/rice/flags.go
@@ -23,7 +23,7 @@ var flags struct {
 	EmbedSyso struct{} `command:"embed-syso"`
 	Clean     struct{} `command:"clean"`
 
-	Tags []string `long:"tags" description:"Tags to use"`
+	Tags []string `long:"tags" description:"Tags to use with the implicit go build"`
 }
 
 // flags parser

--- a/rice/main.go
+++ b/rice/main.go
@@ -25,6 +25,7 @@ func main() {
 	var pkgs []*build.Package
 	for _, importPath := range flags.ImportPaths {
 		pkg := pkgForPath(importPath)
+		pkg.AllTags = flags.Tags
 		pkgs = append(pkgs, pkg)
 	}
 


### PR DESCRIPTION
Allow sepcifying tags, and pass them to go/build.