### PR TITLE
output path flag

### DIFF
--- a/rice/clean.go
+++ b/rice/clean.go
@@ -7,8 +7,12 @@ import (
 	"path/filepath"
 )
 
-func operationClean(pkg *build.Package) {
-	filepath.Walk(pkg.Dir, func(filename string, info os.FileInfo, err error) error {
+func operationClean(pkg *build.Package, outputPath string) {
+	if len(outputPath) == 0 {
+		outputPath = pkg.Dir
+	}
+
+	filepath.Walk(outputPath, func(filename string, info os.FileInfo, err error) error {
 		if err != nil {
 			fmt.Printf("error walking pkg dir to clean files: %v\n", err)
 			os.Exit(1)

--- a/rice/embed-go.go
+++ b/rice/embed-go.go
@@ -154,9 +154,13 @@ func writeBoxesGo(pkg *build.Package, out io.Writer) error {
 	return nil
 }
 
-func operationEmbedGo(pkg *build.Package) {
+func operationEmbedGo(pkg *build.Package, outputPath string) {
+	if len(outputPath) == 0 {
+		outputPath = pkg.Dir
+	}
+
 	// create go file for box
-	boxFile, err := os.Create(filepath.Join(pkg.Dir, boxFilename))
+	boxFile, err := os.Create(filepath.Join(outputPath, boxFilename))
 	if err != nil {
 		log.Printf("error creating embedded box file: %s\n", err)
 		os.Exit(1)

--- a/rice/embed-syso.go
+++ b/rice/embed-syso.go
@@ -70,7 +70,10 @@ type embeddedSysoHelperData struct {
 	Symname string
 }
 
-func operationEmbedSyso(pkg *build.Package) {
+func operationEmbedSyso(pkg *build.Package, outputPath string) {
+	if len(outputPath) == 0 {
+		outputPath = pkg.Dir
+	}
 
 	regexpSynameReplacer := regexp.MustCompile(`[^a-z0-9_]`)
 
@@ -86,7 +89,7 @@ func operationEmbedSyso(pkg *build.Package) {
 
 	for boxname := range boxMap {
 		// find path and filename for this box
-		boxPath := filepath.Join(pkg.Dir, boxname)
+		boxPath := filepath.Join(outputPath, boxname)
 		boxFilename := strings.Replace(boxname, "/", "-", -1)
 		boxFilename = strings.Replace(boxFilename, "..", "back", -1)
 		boxFilename = strings.Replace(boxFilename, ".", "-", -1)

--- a/rice/flags.go
+++ b/rice/flags.go
@@ -14,6 +14,7 @@ var flags struct {
 	CpuProfile  string   `long:"cpuprofile" description:"Write cpu profile to this file"`
 	Verbose     bool     `long:"verbose" short:"v" description:"Show verbose debug information"`
 	ImportPaths []string `long:"import-path" short:"i" description:"Import path(s) to use. Using PWD when left empty. Specify multiple times for more import paths to append"`
+	OutputPath  string   `long:"output-path" short:"o" description:"Output path to use. Using pkg dir when left empty."`
 
 	Append struct {
 		Executable string `long:"exec" description:"Executable to append" required:"true"`

--- a/rice/main.go
+++ b/rice/main.go
@@ -33,18 +33,18 @@ func main() {
 	switch flagsParser.Active.Name {
 	case "embed", "embed-go":
 		for _, pkg := range pkgs {
-			operationEmbedGo(pkg)
+			operationEmbedGo(pkg, flags.OutputPath)
 		}
 	case "embed-syso":
 		log.Println("WARNING: embedding .syso is experimental..")
 		for _, pkg := range pkgs {
-			operationEmbedSyso(pkg)
+			operationEmbedSyso(pkg, flags.OutputPath)
 		}
 	case "append":
 		operationAppend(pkgs)
 	case "clean":
 		for _, pkg := range pkgs {
-			operationClean(pkg)
+			operationClean(pkg, flags.OutputPath)
 		}
 	}
 


### PR DESCRIPTION
Added a new flag to allow specifying the output path

```go
OutputPath  string   `long:"output-path" short:"o" description:"Output path to use. Using pkg dir when left empty."`
```

Usage:

```sh
$ rice -i foo/bar -o build/out embed-go # result will be build/out/rice-box.go
```