### PR TITLE
add 'append-dir' command for appending boxes without access to source code

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,17 @@ go build -o example
 rice append --exec example
 ```
 
+### `rice append-dir`: Append directories to executable as zip file
+
+Similar to the `append` command, this method changes an already-built executable by adding appending a zipfile. The difference from `append` is that it does not require for the source code to be accessible; in order to achieve this, you have to specify a list of directories to append.
+
+Run the following commands to create a standalone executable.
+
+```bash
+go build -o example
+rice append --exec example -d foo -d bar
+```
+
 ## Help information
 
 Run `rice --help` for information about all flags and subcommands.

--- a/rice/append.go
+++ b/rice/append.go
@@ -14,6 +14,33 @@ import (
 )
 
 func operationAppend(pkgs []*build.Package) {
+	boxes := make(map[string]string)
+	for _, pkg := range pkgs {
+		// find boxes for this command
+		boxMap := findBoxes(pkg)
+
+		// notify user when no calls to rice.FindBox are made (is this an error and therefore os.Exit(1) ?
+		if len(boxMap) == 0 {
+			fmt.Printf("no calls to rice.FindBox() or rice.MustFindBox() found in import path `%s`\n", pkg.ImportPath)
+			continue
+		}
+
+		verbosef("\n")
+
+		for boxname := range boxMap {
+			appendedBoxName := strings.Replace(boxname, `/`, `-`, -1)
+
+			// walk box path's and insert files
+			boxPath := filepath.Clean(filepath.Join(pkg.Dir, boxname))
+
+			boxes[appendedBoxName] = boxPath
+		}
+	}
+	appendBoxes(boxes)
+}
+
+// append boxes (key: box name, value: filesystem path)
+func appendBoxes(boxes map[string]string) {
 	// create tmp zipfile
 	tmpZipfileName := filepath.Join(os.TempDir(), fmt.Sprintf("ricebox-%d-%s.zip", time.Now().Unix(), randomString(10)))
 	verbosef("Will create tmp zipfile: %s\n", tmpZipfileName)
@@ -61,72 +88,55 @@ func operationAppend(pkgs []*build.Package) {
 	// write the zip offset into the zip data
 	zipWriter.SetOffset(binfileInfo.Size())
 
-	for _, pkg := range pkgs {
-		// find boxes for this command
-		boxMap := findBoxes(pkg)
-
-		// notify user when no calls to rice.FindBox are made (is this an error and therefore os.Exit(1) ?
-		if len(boxMap) == 0 {
-			fmt.Printf("no calls to rice.FindBox() or rice.MustFindBox() found in import path `%s`\n", pkg.ImportPath)
-			continue
-		}
-
-		verbosef("\n")
-
-		for boxname := range boxMap {
-			appendedBoxName := strings.Replace(boxname, `/`, `-`, -1)
-
-			// walk box path's and insert files
-			boxPath := filepath.Clean(filepath.Join(pkg.Dir, boxname))
-			filepath.Walk(boxPath, func(path string, info os.FileInfo, err error) error {
-				if info == nil {
-					fmt.Printf("Error: box \"%s\" not found on disk\n", path)
-					os.Exit(1)
+	for appendedBoxName, boxPath := range boxes {
+		filepath.Walk(boxPath, func(path string, info os.FileInfo, err error) error {
+			if info == nil {
+				fmt.Printf("Error: box \"%s\" not found on disk\n", path)
+				os.Exit(1)
+			}
+			// create zipFilename
+			zipFileName := filepath.Join(appendedBoxName, strings.TrimPrefix(path, boxPath))
+			// write directories as empty file with comment "dir"
+			if info.IsDir() {
+				header := &zip.FileHeader{
+					Name:    zipFileName,
+					Comment: "dir",
 				}
-				// create zipFilename
-				zipFileName := filepath.Join(appendedBoxName, strings.TrimPrefix(path, boxPath))
-				// write directories as empty file with comment "dir"
-				if info.IsDir() {
-					header := &zip.FileHeader{
-						Name:     zipFileName,
-						Comment:  "dir",
-					}
-					header.SetModTime(info.ModTime())
-					_, err := zipWriter.CreateHeader(header)
-					if err != nil {
-						fmt.Printf("Error creating dir in tmp zip: %s\n", err)
-						os.Exit(1)
-					}
-					return nil
-				}
-
-				// create zipFileWriter
-				zipFileHeader, err := zip.FileInfoHeader(info)
+				header.SetModTime(info.ModTime())
+				_, err := zipWriter.CreateHeader(header)
 				if err != nil {
-					fmt.Printf("Error creating zip FileHeader: %v\n", err)
+					fmt.Printf("Error creating dir in tmp zip: %s\n", err)
 					os.Exit(1)
 				}
-				zipFileHeader.Name = zipFileName
-				zipFileWriter, err := zipWriter.CreateHeader(zipFileHeader)
-				if err != nil {
-					fmt.Printf("Error creating file in tmp zip: %s\n", err)
-					os.Exit(1)
-				}
-				srcFile, err := os.Open(path)
-				if err != nil {
-					fmt.Printf("Error opening file to append: %s\n", err)
-					os.Exit(1)
-				}
-				_, err = io.Copy(zipFileWriter, srcFile)
-				if err != nil {
-					fmt.Printf("Error copying file contents to zip: %s\n", err)
-					os.Exit(1)
-				}
-				srcFile.Close()
-
 				return nil
-			})
-		}
+			}
+
+			// create zipFileWriter
+			zipFileHeader, err := zip.FileInfoHeader(info)
+			if err != nil {
+				fmt.Printf("Error creating zip FileHeader: %v\n", err)
+				os.Exit(1)
+			}
+			zipFileHeader.Name = zipFileName
+			zipFileWriter, err := zipWriter.CreateHeader(zipFileHeader)
+			if err != nil {
+				fmt.Printf("Error creating file in tmp zip: %s\n", err)
+				os.Exit(1)
+			}
+			srcFile, err := os.Open(path)
+			if err != nil {
+				fmt.Printf("Error opening file to append: %s\n", err)
+				os.Exit(1)
+			}
+			_, err = io.Copy(zipFileWriter, srcFile)
+			if err != nil {
+				fmt.Printf("Error copying file contents to zip: %s\n", err)
+				os.Exit(1)
+			}
+			srcFile.Close()
+
+			return nil
+		})
 	}
 
 	err = zipWriter.Close()

--- a/rice/append.go
+++ b/rice/append.go
@@ -36,11 +36,25 @@ func operationAppend(pkgs []*build.Package) {
 			boxes[appendedBoxName] = boxPath
 		}
 	}
-	appendBoxes(boxes)
+	appendBoxes(flags.Append.Executable, boxes)
+}
+
+func operationAppendDir(dirs []string) {
+	boxes := make(map[string]string)
+	for _, dir := range dirs {
+		appendedBoxName := strings.Replace(dir, `/`, `-`, -1)
+		boxes[appendedBoxName] = dir
+	}
+
+	if len(flags.AppendDir.Dirs) == 0 {
+		fmt.Print("You should specify at least one directory to append. Please use -d or --dir option.\n")
+		os.Exit(1)
+	}
+	appendBoxes(flags.AppendDir.Executable, boxes)
 }
 
 // append boxes (key: box name, value: filesystem path)
-func appendBoxes(boxes map[string]string) {
+func appendBoxes(executable string, boxes map[string]string) {
 	// create tmp zipfile
 	tmpZipfileName := filepath.Join(os.TempDir(), fmt.Sprintf("ricebox-%d-%s.zip", time.Now().Unix(), randomString(10)))
 	verbosef("Will create tmp zipfile: %s\n", tmpZipfileName)
@@ -55,7 +69,7 @@ func appendBoxes(boxes map[string]string) {
 	}()
 
 	// find abs path for binary file
-	binfileName, err := filepath.Abs(flags.Append.Executable)
+	binfileName, err := filepath.Abs(executable)
 	if err != nil {
 		fmt.Printf("Error finding absolute path for executable to append: %s\n", err)
 		os.Exit(1)

--- a/rice/flags.go
+++ b/rice/flags.go
@@ -19,6 +19,11 @@ var flags struct {
 		Executable string `long:"exec" description:"Executable to append" required:"true"`
 	} `command:"append"`
 
+	AppendDir struct {
+		Executable string   `long:"exec" description:"Executable to append" required:"true"`
+		Dirs       []string `long:"dir" short:"d" description:"Directory to append (relative to PWD). Specify multiple times for more directories to append"`
+	} `command:"append-dir" required:"true"`
+
 	EmbedGo   struct{} `command:"embed-go" alias:"embed"`
 	EmbedSyso struct{} `command:"embed-syso"`
 	Clean     struct{} `command:"clean"`

--- a/rice/main.go
+++ b/rice/main.go
@@ -34,6 +34,8 @@ func main() {
 		}
 	case "append":
 		operationAppend(getPkgs())
+	case "append-dir":
+		operationAppendDir(flags.AppendDir.Dirs)
 	case "clean":
 		for _, pkg := range getPkgs() {
 			operationClean(pkg)

--- a/rice/main.go
+++ b/rice/main.go
@@ -21,29 +21,21 @@ func main() {
 		defer pprof.StopCPUProfile()
 	}
 
-	// find package for path
-	var pkgs []*build.Package
-	for _, importPath := range flags.ImportPaths {
-		pkg := pkgForPath(importPath)
-		pkg.AllTags = flags.Tags
-		pkgs = append(pkgs, pkg)
-	}
-
 	// switch on the operation to perform
 	switch flagsParser.Active.Name {
 	case "embed", "embed-go":
-		for _, pkg := range pkgs {
+		for _, pkg := range getPkgs() {
 			operationEmbedGo(pkg)
 		}
 	case "embed-syso":
 		log.Println("WARNING: embedding .syso is experimental..")
-		for _, pkg := range pkgs {
+		for _, pkg := range getPkgs() {
 			operationEmbedSyso(pkg)
 		}
 	case "append":
-		operationAppend(pkgs)
+		operationAppend(getPkgs())
 	case "clean":
-		for _, pkg := range pkgs {
+		for _, pkg := range getPkgs() {
 			operationClean(pkg)
 		}
 	}
@@ -60,6 +52,18 @@ func main() {
 		pprof.WriteHeapProfile(f)
 		f.Close()
 	}
+}
+
+// get all packages from import path
+func getPkgs() []*build.Package {
+	// find package for path
+	var pkgs []*build.Package
+	for _, importPath := range flags.ImportPaths {
+		pkg := pkgForPath(importPath)
+		pkg.AllTags = flags.Tags
+		pkgs = append(pkgs, pkg)
+	}
+	return pkgs
 }
 
 // helper function to get *build.Package for given path


### PR DESCRIPTION
The append-dir command useful when you have no go source code or even no go installed at all and just want to append boxes.
